### PR TITLE
fix(components): fix box sizing in blip select #155304

### DIFF
--- a/src/scss/components/_select.scss
+++ b/src/scss/components/_select.scss
@@ -63,6 +63,7 @@
   align-self: center;
   position: relative;
   z-index: 1;
+  box-sizing: initial;
 
   &:focus { outline: none; }
 }


### PR DESCRIPTION
bugfix/155304-add_box_sizing_to_select