### PR TITLE
fix(components): fixing blip-select icon when the description is at bottom

### DIFF
--- a/src/scss/components/_select.scss
+++ b/src/scss/components/_select.scss
@@ -333,7 +333,6 @@
 
   .blip-select__option__content {
     margin-left: 10px;
-    width: 100%;
 
     span {
       display: block;


### PR DESCRIPTION
…otton

bugfix/167457-fix-blip-select-icon