### PR TITLE
#196561 - Fixing time selection in dateRangePicker

### DIFF
--- a/src/components/blipDatepicker/index.js
+++ b/src/components/blipDatepicker/index.js
@@ -580,7 +580,9 @@ export class BlipDatepicker extends Component {
 
   _onTimeInputChange = event => {
     const [hour, minute] = event.target.value.split(':')
-    this._monthDate.setHours(hour, minute)
+    if (hour && minute) {
+      this._monthDate.setHours(hour, minute)
+    }
 
     if (this.onTimeChange) this.onTimeChange()
   }

--- a/src/components/blipDaterangepicker/index.js
+++ b/src/components/blipDaterangepicker/index.js
@@ -196,7 +196,7 @@ export class BlipDaterangepicker extends Component {
   _pickerNotActive = () => {
     if (this._selectedPeriod) {
       this._leftPicker.monthDate = this._selectedPeriod.startDate
-      this._rightPicker.monthDate = DateHelper.moveMonth(this._selectedPeriod.startDate, 1)
+      this._rightPicker.monthDate = DateHelper.moveMonth(this._selectedPeriod.endDate, 1)
       this._setButtonsVisibility()
     }
 


### PR DESCRIPTION
When a user inputed time with number '0' eg: '04' the component breakes. So, fixing this issue and
also fixing selected endTime showing. It was showing startTime in order to endTime.

ISSUES CLOSED: #196561

bugfix/196561-fixing-time-selection