### PR TITLE
Fixing selected time showing

### DIFF
--- a/src/components/blipDaterangepicker/index.js
+++ b/src/components/blipDaterangepicker/index.js
@@ -66,7 +66,7 @@ export class BlipDaterangepicker extends Component {
     this._setDateOnInput(period.endDate, this.endDateInput)
 
     this._leftPicker.monthDate = period.startDate
-    this._rightPicker.monthDate = DateHelper.moveMonth(period.startDate, 1)
+    this._rightPicker.monthDate = DateHelper.moveMonth(period.endDate, 1)
   }
 
   createElement() {


### PR DESCRIPTION
When a user select endtime and search, it was showing value from startTime when reopen the picker. So, fixing selected endtime showing

ISSUES CLOSED: #196561

bugfix/196561-fixing-time-selection