### PR TITLE
fix(components): fixing daterangpicker month exibition

### DIFF
--- a/src/components/blipDaterangepicker/index.js
+++ b/src/components/blipDaterangepicker/index.js
@@ -66,7 +66,7 @@ export class BlipDaterangepicker extends Component {
     this._setDateOnInput(period.endDate, this.endDateInput)
 
     this._leftPicker.monthDate = period.startDate
-    this._rightPicker.monthDate = DateHelper.moveMonth(period.endDate, 1)
+    this._rightPicker.monthDate = DateHelper.moveMonth(period.startDate, 1, period.endDate)
   }
 
   createElement() {
@@ -196,7 +196,7 @@ export class BlipDaterangepicker extends Component {
   _pickerNotActive = () => {
     if (this._selectedPeriod) {
       this._leftPicker.monthDate = this._selectedPeriod.startDate
-      this._rightPicker.monthDate = DateHelper.moveMonth(this._selectedPeriod.endDate, 1)
+      this._rightPicker.monthDate = DateHelper.moveMonth(this._selectedPeriod.startDate, 1, this._selectedPeriod.endDate)
       this._setButtonsVisibility()
     }
 

--- a/src/components/shared/DateHelper.js
+++ b/src/components/shared/DateHelper.js
@@ -11,13 +11,13 @@ export class DateHelper {
     )
   }
 
-  static moveMonth(sourceDate, offset) {
+  static moveMonth(sourceDate, offset, sourceTime = sourceDate) {
     return new Date(
       sourceDate.getFullYear(),
       sourceDate.getMonth() + offset,
       sourceDate.getDate(),
-      sourceDate.getHours(),
-      sourceDate.getMinutes()
+      sourceTime.getHours(),
+      sourceTime.getMinutes()
     )
   }
 


### PR DESCRIPTION
Creating a new not required parameter to movemonth method to keep month exibition working and keep
right time on endtime

ISSUES CLOSED: 199960